### PR TITLE
🔧 build(pyproject): regenerate `pyproject.toml` and `poetry.lock`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -848,5 +848,5 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.11"
-content-hash = "de37ac886ba95e6ea980266c646c89d355adb79b71a3cd6235155c121e23ec48"
+python-versions = ">=3.11,<4"
+content-hash = "05cf539bf685c73b39546d7664569dfffb242ed75ec67eb60da8c9f0a3bbd50c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,21 @@
-[tool.poetry]
+[project]
 name = "readings"
 version = "0.1.0"
 description = ""
-authors = ["mukappalambda <maokailan24@gmail.com>"]
+authors = [
+    {name = "mukappalambda",email = "maokailan24@gmail.com"}
+]
 readme = "README.md"
+requires-python = ">=3.11,<4"
+dependencies = [
+    "mkdocs-material (==9.5.34)",
+    "mkdocs-git-revision-date-localized-plugin (==1.2.6)",
+    "mkdocs-git-committers-plugin-2 (==2.3.0)"
+]
+
+[tool.poetry]
 package-mode = false
 
-[tool.poetry.dependencies]
-python = "^3.11"
-mkdocs-material = "9.5.34"
-mkdocs-git-revision-date-localized-plugin = "1.2.6"
-mkdocs-git-committers-plugin-2 = "2.3.0"
-
-
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
As there are deprecation warnings when executing the `poetry check` command.

```console
$ poetry --version
Poetry (version 2.1.1)
$ poetry check
Warning: [tool.poetry.name] is deprecated. Use [project.name] instead.
Warning: [tool.poetry.version] is set but 'version' is not in [project.dynamic]. If it is static use [project.version]. If it is dynamic, add 'version' to [project.dynamic].
If you want to set the version dynamically via `poetry build --local-version` or you are using a plugin, which sets the version dynamically, you should define the version in [tool.poetry] and add 'version' to [project.dynamic].
Warning: [tool.poetry.description] is deprecated. Use [project.description] instead.
Warning: [tool.poetry.readme] is set but 'readme' is not in [project.dynamic]. If it is static use [project.readme]. If it is dynamic, add 'readme' to [project.dynamic].
If you want to define multiple readmes, you should define them in [tool.poetry] and add 'readme' to [project.dynamic].
Warning: [tool.poetry.authors] is deprecated. Use [project.authors] instead.
```