### PR TITLE
🔧 chore(workflow): update caching action to v4.3.0

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,7 +26,7 @@ jobs:
             pyproject.toml
             poetry.lock
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache


### PR DESCRIPTION
Updated the GitHub Actions cache action to use version 4.3.0 for improved performance and reliability in the documentation workflow.