### PR TITLE
🔒️ build(deps): upgrade urllib3 from 2.6.0 to 2.6.3 (#68)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -717,14 +717,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.0"
+version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.6.0-py3-none-any.whl", hash = "sha256:c90f7a39f716c572c4e3e58509581ebd83f9b59cced005b7db7ad2d22b0db99f"},
-    {file = "urllib3-2.6.0.tar.gz", hash = "sha256:cb9bcef5a4b345d5da5d145dc3e30834f58e8018828cbc724d30b4cb7d4d49f1"},
+    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
+    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
 ]
 
 [package.extras]


### PR DESCRIPTION
**Actual Result**

```console
➜  readings git:(68-upgrade-urllib3-version) trivy repo --scanners vuln,misconfig,secret .
2026-01-18T15:19:39+08:00	INFO	[vuln] Vulnerability scanning is enabled
2026-01-18T15:19:39+08:00	INFO	[misconfig] Misconfiguration scanning is enabled
2026-01-18T15:19:40+08:00	INFO	[secret] Secret scanning is enabled
2026-01-18T15:19:40+08:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln,misconfig' to disable secret scanning
2026-01-18T15:19:40+08:00	INFO	[secret] Please see https://trivy.dev/docs/v0.68/guide/scanner/secret#recommendation for faster secret detection
2026-01-18T15:19:40+08:00	INFO	Number of language-specific files	num=1
2026-01-18T15:19:40+08:00	INFO	[poetry] Detecting vulnerabilities...
2026-01-18T15:19:40+08:00	INFO	Detected config files	num=0

Report Summary

┌─────────────┬────────┬─────────────────┬───────────────────┬─────────┐
│   Target    │  Type  │ Vulnerabilities │ Misconfigurations │ Secrets │
├─────────────┼────────┼─────────────────┼───────────────────┼─────────┤
│ poetry.lock │ poetry │        0        │         -         │    -    │
└─────────────┴────────┴─────────────────┴───────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```